### PR TITLE
Fix issues causing npm run dev to not work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+npm-debug.log

--- a/src/components/visible-todo-list/index.js
+++ b/src/components/visible-todo-list/index.js
@@ -6,7 +6,7 @@ import TodoList from './todo-list'
 import Error from 'components/error'
 
 // Class Definition
-export default class VisibleTodoList extends Component {
+class VisibleTodoList extends Component {
   componentDidMount () {
     this.fetchData()
   }

--- a/src/store.js
+++ b/src/store.js
@@ -10,12 +10,14 @@ export const configureStore = () => {
   // Conditionally apply logging middlware when not in production
   if (process.env.NODE_ENV !== 'production') middlewares.push(createLogger())
 
+  // Support both having redux devtools extension enabled and not
+  const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+
   // Create store
   return createStore(
     reducer,
-    compose(
-      applyMiddleware(...middlewares),
-      window.devToolsExtension && window.devToolsExtension()
+    composeEnhancers(
+      applyMiddleware(...middlewares)
     )
   )
 }


### PR DESCRIPTION
Just some random fixes to make it possible to `npm run dev`:

- Fixes an issue where `export default` was done both on the VisibleTodoList class and its connected/withRouter wrapped instantiation.  It just needed to be on the later (and the class didn't need to be exported)
- If you don't have the redux devtools extension installed, the compose call would cause the app to not build as it doesn't play well with undefined.  I just followed the [example](https://github.com/zalmoxisus/redux-devtools-extension#12-advanced-store-setup) code in the extension's readme to make this work fine (also installed the extension and verified it does work)
- just a quick addition of npm logs to the .gitignore